### PR TITLE
feat: add web tapper tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,4 @@ node_modules
 .lock-wscript
 
 # gh-pages
-web
 web_dist

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,191 @@
+import {mapTapsToWords, nudgeWord} from './mapping.js';
+import {exportJSON, exportCSV, importJSON, autosave, loadAutosave} from './storage.js';
+import {initTimeline, getSelected, setSelected} from './waveform.js';
+
+const state={
+  meta:{title:'',audioName:'',duration:0,countdownSec:3,latencyMs:0,mode:'hold',version:1},
+  tracks:{lyrics:[],kick:[],snare:[],guitar:[],extra:[]},
+  mapped:{words:[]},
+  activeTrack:'lyrics'
+};
+
+const audio=document.getElementById('audio');
+initTimeline(state,audio);
+
+const els={
+  title:document.getElementById('title'),
+  url:document.getElementById('audio-url'),
+  file:document.getElementById('audio-file'),
+  countdown:document.getElementById('countdown'),
+  latency:document.getElementById('latency'),
+  mode:document.getElementById('mode'),
+  activeTrack:document.getElementById('active-track'),
+  loadBtn:document.getElementById('load-audio'),
+  startBtn:document.getElementById('start'),
+  stopBtn:document.getElementById('stop'),
+  lyrics:document.getElementById('lyrics'),
+  mapBtn:document.getElementById('map'),
+  clearLyrics:document.getElementById('clear-lyrics'),
+  importBtn:document.getElementById('import-json'),
+  exportBtn:document.getElementById('export-json'),
+  exportCsvBtn:document.getElementById('export-csv'),
+  resetBtn:document.getElementById('reset'),
+  status:document.getElementById('status'),
+  table:document.querySelector('#events tbody'),
+  preview:document.getElementById('preview'),
+  clock:document.getElementById('clock'),
+  nudgeBtns:[...document.querySelectorAll('#nudge button')]
+};
+
+els.loadBtn.onclick=()=>loadAudio({file:els.file.files[0], url:els.url.value});
+els.startBtn.onclick=()=>start(parseInt(els.countdown.value||'0',10));
+els.stopBtn.onclick=stop;
+els.mapBtn.onclick=()=>{try{map();}catch(e){els.status.textContent=e.message;}};
+els.clearLyrics.onclick=()=>{els.lyrics.value='';};
+els.importBtn.onclick=()=>{
+  const txt=prompt('Paste JSON');
+  if(!txt) return; try{importJSON(state,JSON.parse(txt));updateTable();}catch(e){alert('Invalid JSON');}
+};
+els.exportBtn.onclick=()=>{const data=exportJSON(state);download('taps.json',data);};
+els.exportCsvBtn.onclick=()=>{const data=exportCSV(state);download('taps.csv',data);};
+els.resetBtn.onclick=()=>{location.reload();};
+els.mode.onchange=()=>state.meta.mode=els.mode.value;
+els.activeTrack.onchange=()=>state.activeTrack=els.activeTrack.value;
+els.title.oninput=()=>state.meta.title=els.title.value;
+els.latency.oninput=()=>state.meta.latencyMs=parseInt(els.latency.value||'0',10);
+
+function download(name,data){
+  const a=document.createElement('a');
+  a.href=URL.createObjectURL(new Blob([data]));
+  a.download=name; a.click();
+}
+
+function loadAudio({file,url}){
+  return new Promise((resolve,reject)=>{
+    if(file){
+      const obj=URL.createObjectURL(file);
+      audio.src=obj; state.meta.audioName=file.name;
+    }else if(url){ audio.src=url; state.meta.audioName=url; }
+    audio.onloadedmetadata=()=>{state.meta.duration=audio.duration;resolve();};
+    audio.onerror=reject;
+  });
+}
+
+let recording=false;
+let lastSpace=null;
+function start(count){
+  if(recording) return; state.countdownSec=count; let sec=count;
+  els.status.textContent='Get ready...';
+  const int=setInterval(()=>{
+    els.status.textContent=sec>0?sec: 'GO';
+    if(sec--<=0){clearInterval(int);begin();}
+  },1000);
+}
+function begin(){
+  recording=true; state.tracks={lyrics:[],kick:[],snare:[],guitar:[],extra:[]};
+  audio.currentTime=0; audio.play();
+}
+function stop(){ recording=false; audio.pause(); }
+
+document.addEventListener('keydown',e=>{
+  if(!recording) return;
+  if(e.code==='Space'){
+    e.preventDefault();
+    if(state.meta.mode==='hold'){ lastSpace=audio.currentTime+state.meta.latencyMs/1000; }
+    else state.tracks.lyrics.push({t:audio.currentTime+state.meta.latencyMs/1000});
+    updateTable();
+  } else if(state.meta.mode==='tap'){
+    const keyMap={'Digit1':'kick','Digit2':'snare','Digit3':'guitar','Digit4':'extra'};
+    const track=keyMap[e.code];
+    if(track){state.tracks[track].push({t:audio.currentTime+state.meta.latencyMs/1000});updateTable();}
+  }
+  if(e.code==='Backspace'){
+    e.preventDefault();
+    const arr=state.tracks[state.activeTrack];
+    arr.pop();updateTable();
+  }
+});
+
+document.addEventListener('keyup',e=>{
+  if(!recording) return;
+  if(state.meta.mode==='hold' && e.code==='Space' && lastSpace!=null){
+    const t1=audio.currentTime+state.meta.latencyMs/1000;
+    state.tracks.lyrics.push({t0:lastSpace,t1});
+    lastSpace=null; updateTable();
+  }
+});
+
+window.addEventListener('keydown',e=>{ if(e.code==='Space') e.preventDefault(); }, {passive:false});
+
+function updateTable(){
+  const tbody=els.table; tbody.innerHTML='';
+  for(const [track,arr] of Object.entries(state.tracks)){
+    arr.forEach(ev=>{
+      const tr=document.createElement('tr');
+      const t0=(ev.t0??ev.t).toFixed(3);
+      const t1=(ev.t1??ev.t).toFixed(3);
+      const dur=(ev.t1? (ev.t1-ev.t0).toFixed(3):'');
+      tr.innerHTML=`<td>${track}</td><td>${t0}</td><td>${t1}</td><td>${dur}</td>`;
+      tbody.appendChild(tr);
+    });
+  }
+}
+
+function map(){
+  const words=els.lyrics.value.trim().split(/\s+/).filter(Boolean);
+  state.mapped.words=mapTapsToWords(state.meta.mode,state.tracks.lyrics,words,state.meta.duration);
+  renderPreview();
+}
+
+function renderPreview(){
+  const frag=document.createDocumentFragment();
+  state.mapped.words.forEach((w,i)=>{
+    const span=document.createElement('span');
+    span.textContent=w.text+' ';
+    span.dataset.index=i;
+    span.onclick=()=>{sel=i; setSelected(i);};
+    frag.appendChild(span);
+  });
+  els.preview.innerHTML=''; els.preview.appendChild(frag);
+}
+
+els.nudgeBtns.forEach(btn=>{
+  btn.addEventListener('click',()=>{
+    const idx=getSelected();
+    if(idx<0) return;
+    nudgeWord(state.mapped.words,idx,parseFloat(btn.dataset.d)*1000,'both',state.meta.duration);
+    const seg=state.tracks.lyrics[idx];
+    const w=state.mapped.words[idx];
+    if(seg){seg.t0=w.t0;seg.t1=w.t1;}
+    updateTable();
+  });
+});
+
+let sel=-1;
+function tick(){
+  els.clock.textContent='Now: '+audio.currentTime.toFixed(3)+'s';
+  const t=audio.currentTime;
+  const i=state.mapped.words.findIndex(w=>t>=w.t0 && t<w.t1);
+  if(i!==sel){
+    sel=i; [...els.preview.children].forEach((sp,n)=>sp.classList.toggle('active',n===i));
+  }
+  requestAnimationFrame(tick);
+}
+requestAnimationFrame(tick);
+
+// Autosave
+setInterval(()=>autosave(state),3000);
+const saved=loadAutosave(); if(saved) {importJSON(state,saved); updateTable(); renderPreview();}
+
+// Public API
+window.Tapper={
+  getState:()=>state,
+  loadAudio,
+  start:count=>start(count),
+  stop,
+  mapToLyrics:text=>{els.lyrics.value=text; map();},
+  exportJSON:()=>JSON.parse(exportJSON(state)),
+  exportCSV:()=>exportCSV(state),
+  importJSON:obj=>{importJSON(state,obj); updateTable(); renderPreview();},
+  nudgeWord:(i,ms,edge)=>{nudgeWord(state.mapped.words,i,ms,edge,state.meta.duration);}
+};

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Lyric/Instrument Tapper</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="app">
+    <div id="left">
+      <h1>Tapper</h1>
+      <label>Title <input id="title" type="text" /></label>
+      <label>Audio URL <input id="audio-url" type="text" /></label>
+      <label>Audio File <input id="audio-file" type="file" accept="audio/*" /></label>
+      <label>Countdown (sec) <input id="countdown" type="number" value="3" /></label>
+      <label>Latency (ms) <input id="latency" type="number" value="0" /></label>
+      <label>Mode
+        <select id="mode">
+          <option value="hold">Hold</option>
+          <option value="tap">Tap</option>
+        </select>
+      </label>
+      <label>Active Track
+        <select id="active-track">
+          <option value="lyrics">Lyrics</option>
+          <option value="kick">Kick</option>
+          <option value="snare">Snare</option>
+          <option value="guitar">Guitar</option>
+          <option value="extra">Extra</option>
+        </select>
+      </label>
+      <button id="load-audio">Load audio</button>
+      <button id="start">Start + Countdown</button>
+      <button id="stop">Stop</button>
+      <audio id="audio" controls></audio>
+      <textarea id="lyrics" placeholder="Paste lyrics here"></textarea>
+      <div class="row">
+        <button id="map">Map to taps</button>
+        <button id="clear-lyrics">Clear</button>
+      </div>
+      <div class="row">
+        <button id="import-json">Import JSON</button>
+        <button id="export-json">Export JSON</button>
+        <button id="export-csv">Export CSV</button>
+        <button id="reset">Reset</button>
+      </div>
+      <div id="status"></div>
+    </div>
+    <div id="right">
+      <div id="clock">Now: 0.000s</div>
+      <canvas id="waveform" width="800" height="120"></canvas>
+      <div id="preview"></div>
+      <div id="nudge">
+        <button data-d="-0.05">-50ms</button>
+        <button data-d="-0.005">-5ms</button>
+        <button data-d="-0.001">-1ms</button>
+        <button data-d="0.001">+1ms</button>
+        <button data-d="0.005">+5ms</button>
+        <button data-d="0.05">+50ms</button>
+      </div>
+      <table id="events"><thead><tr><th>Track</th><th>t0</th><th>t1</th><th>dur</th></tr></thead><tbody></tbody></table>
+    </div>
+  </div>
+  <script src="../dist/tappy.min.js"></script>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/web/mapping.js
+++ b/web/mapping.js
@@ -1,0 +1,31 @@
+export function clampTime(t, duration){
+  return Math.max(0, Math.min(duration, t));
+}
+
+export function mapTapsToWords(mode, taps, words, duration){
+  const mapped=[];
+  if(mode==='hold'){
+    if(words.length!==taps.length) throw new Error('Word count mismatch');
+    for(let i=0;i<words.length;i++){
+      const seg=taps[i];
+      mapped.push({text:words[i], t0:clampTime(seg.t0,duration), t1:clampTime(seg.t1,duration)});
+    }
+  }else{
+    if(words.length!==taps.length) throw new Error('Word count mismatch');
+    for(let i=0;i<words.length;i++){
+      const t0=clampTime(taps[i].t,duration);
+      const t1=i<words.length-1?clampTime(taps[i+1].t,duration):clampTime(t0+0.25,duration);
+      mapped.push({text:words[i], t0, t1});
+    }
+  }
+  return mapped;
+}
+
+export function nudgeWord(words,index,ms,edge,duration){
+  const w=words[index];
+  if(!w) return;
+  const dt=ms/1000;
+  if(edge==='start'||edge==='both') w.t0=clampTime(w.t0+dt,duration);
+  if(edge==='end'||edge==='both') w.t1=clampTime(w.t1+dt,duration);
+  if(w.t1<w.t0) w.t1=w.t0;
+}

--- a/web/storage.js
+++ b/web/storage.js
@@ -1,0 +1,33 @@
+const KEY='tapper_autosave_v1';
+
+export function exportJSON(state){
+  return JSON.stringify({meta:state.meta, tracks:state.tracks, mapped:state.mapped}, null, 2);
+}
+
+export function exportCSV(state){
+  const rows=[];
+  for(const [track,arr] of Object.entries(state.tracks)){
+    arr.forEach(ev=>{
+      const t0=ev.t0??ev.t;
+      const t1=ev.t1??ev.t;
+      rows.push([track,t0,t1,(t1-t0).toFixed(3)].join(','));
+    });
+  }
+  return rows.join('\n');
+}
+
+export function importJSON(state,obj){
+  if(obj.meta) state.meta=Object.assign(state.meta,obj.meta);
+  if(obj.tracks) state.tracks=Object.assign(state.tracks,obj.tracks);
+  if(obj.mapped) state.mapped=obj.mapped;
+}
+
+export function autosave(state){
+  localStorage.setItem(KEY,exportJSON(state));
+}
+
+export function loadAutosave(){
+  const str=localStorage.getItem(KEY);
+  if(!str) return null;
+  try{return JSON.parse(str);}catch(e){return null;}
+}

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,17 @@
+body{font-family:sans-serif;color:#eee;background:#222;margin:0;display:flex;justify-content:center}
+#app{display:flex;width:100%;max-width:1200px}
+#left,#right{padding:10px}
+#left{width:300px;background:#333}
+#left label{display:block;margin:4px 0}
+#left input,#left select,#left textarea{width:100%}
+#left textarea{height:100px}
+.row{margin:5px 0}
+button{margin:2px}
+#right{flex:1;background:#111}
+#waveform{background:#000;width:100%}
+#preview{margin:10px 0;min-height:24px}
+#preview .active{color:#0f0}
+#events{width:100%;max-height:200px;overflow:auto}
+#events td,#events th{padding:2px 4px;border-bottom:1px solid #444}
+#clock{margin-bottom:5px}
+#nudge{margin-top:5px}

--- a/web/waveform.js
+++ b/web/waveform.js
@@ -1,0 +1,72 @@
+let canvas,ctx,state,audio,selIndex=-1;
+
+export function initTimeline(_state,_audio){
+  state=_state;audio=_audio;
+  canvas=document.getElementById('waveform');
+  ctx=canvas.getContext('2d');
+  canvas.addEventListener('mousedown',onDown);
+  canvas.addEventListener('mousemove',onMove);
+  canvas.addEventListener('mouseup',onUp);
+  requestAnimationFrame(draw);
+}
+
+function timeToX(t){return t/state.meta.duration*canvas.width;}
+function xToTime(x){return x/canvas.width*state.meta.duration;}
+
+let drag=null;
+function onDown(e){
+  if(!state.mapped.words) return;
+  const x=e.offsetX;
+  const t=xToTime(x);
+  selIndex=state.mapped.words.findIndex(w=>t>=w.t0&&t<=w.t1);
+  if(selIndex>=0){
+    const w=state.mapped.words[selIndex];
+    const startX=timeToX(w.t0), endX=timeToX(w.t1);
+    if(Math.abs(x-startX)<5) drag={edge:'start',index:selIndex};
+    else if(Math.abs(x-endX)<5) drag={edge:'end',index:selIndex};
+    else drag={edge:'both',index:selIndex,offset:t-w.t0,duration:w.t1-w.t0};
+  }else selIndex=-1;
+}
+function onMove(e){
+  if(!drag) return;
+  const w=state.mapped.words[drag.index];
+  const t=Math.max(0,Math.min(state.meta.duration,xToTime(e.offsetX)));
+  if(drag.edge==='start'){
+    w.t0=Math.max(0,Math.min(t,w.t1));
+  }else if(drag.edge==='end'){
+    w.t1=Math.min(state.meta.duration,Math.max(t,w.t0));
+  }else {
+    w.t0=Math.max(0,Math.min(state.meta.duration-drag.duration,t-drag.offset));
+    w.t1=w.t0+drag.duration;
+  }
+  const seg=state.tracks.lyrics[drag.index];
+  if(seg){seg.t0=w.t0;seg.t1=w.t1;}
+}
+function onUp(e){ drag=null; }
+
+export function getSelected(){return selIndex;}
+export function setSelected(i){selIndex=i;}
+
+function draw(){
+  ctx.fillStyle='#000';ctx.fillRect(0,0,canvas.width,canvas.height);
+  ctx.fillStyle='#0f0';
+  if(state.mapped.words){
+    state.mapped.words.forEach((w,i)=>{
+      const x=timeToX(w.t0), wpx=timeToX(w.t1)-x;
+      ctx.fillStyle=i===selIndex?'#0a0':'#555';
+      ctx.fillRect(x,20,wpx,60);
+    });
+  }
+  // instrument taps
+  ctx.strokeStyle='#f00';
+  ['kick','snare','guitar','extra'].forEach(track=>{
+    (state.tracks[track]||[]).forEach(ev=>{
+      const x=timeToX(ev.t);ctx.beginPath();ctx.moveTo(x,0);ctx.lineTo(x,20);ctx.stroke();
+    });
+  });
+  // playhead
+  if(!isNaN(audio.currentTime)){
+    const x=timeToX(audio.currentTime);ctx.strokeStyle='#fff';ctx.beginPath();ctx.moveTo(x,0);ctx.lineTo(x,canvas.height);ctx.stroke();
+  }
+  requestAnimationFrame(draw);
+}


### PR DESCRIPTION
## Summary
- add standalone `/web` client for capturing lyrics and instrument taps
- support mapping taps to pasted lyrics with timeline preview and nudge controls
- include local storage utilities for export, import and autosave

## Testing
- `npm test` *(fails: process terminated before completion)*

------
https://chatgpt.com/codex/tasks/task_e_68b4958193a4832aad4198627c76ad10